### PR TITLE
fix: improve validations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,4 @@ dist
 out
 *.vsix
 
-
+unpacked_bin

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Make sure the following tools are installed in your environment:
 - [Cloud MTA Build Tool](https://github.com/SAP/cloud-mta-build-tool) to build MTA project.
 - [Cloud Foundry CLI](https://github.com/cloudfoundry/cli) to work with Cloud Foundry.
 - [MultiApps CF CLI Plugin](https://github.com/cloudfoundry-incubator/multiapps-cli-plugin) to deploy MTA archive to Cloud Fountry.
-- [MTA tool](https://github.com/SAP/cloud-mta) for exploring and validating the multitarget application descriptor.
-- [Yeoman-ui extension](https://github.com/SAP/yeoman-ui) to work with wizard.
+- [MTA tool](https://github.com/SAP/cloud-mta) to add MTA modules.
+- [Yeoman-ui extension](https://github.com/SAP/yeoman-ui) to add MTA modules.
 
 ### Download and Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -921,13 +921,13 @@
       }
     },
     "@sap/mta-lib": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@sap/mta-lib/-/mta-lib-1.6.5.tgz",
-      "integrity": "sha512-SSUGYCE48kM03GYch2QQOhFqC6b07QpmUrTkOaSqh4pLz5/lSsLwxIV9W5Rvi3Ww73pyz0jWbr3ocS+Xab+5PA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@sap/mta-lib/-/mta-lib-1.6.6.tgz",
+      "integrity": "sha512-n2T+p5FvQNENfR4GmGRY+l3gEb+koAnLn3bDXn2ad+7Gi0DtGDS2NbwlEYx6mT7uTkjA5lgK4BHEG9kIGjv8ZA==",
       "requires": {
         "cross-spawn": "^7.0.3",
         "fs-extra": "8.1.0",
-        "mta-local": "0.1.9",
+        "mta-local": "0.1.10",
         "temp-dir": "2.0.0",
         "which": "^2.0.2"
       },
@@ -3254,6 +3254,42 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "copy-webpack-plugin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-7.0.0.tgz",
+      "integrity": "sha512-SLjQNa5iE3BoCP76ESU9qYo9ZkEWtXoZxDurHoqPchAFRblJ9g96xTeC560UXBMre1Nx6ixIIUfiY3VcjpJw3g==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.4",
+        "glob-parent": "^5.1.1",
+        "globby": "^11.0.1",
+        "loader-utils": "^2.0.0",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^3.0.2",
+        "schema-utils": "^3.0.0",
+        "serialize-javascript": "^5.0.1"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        }
+      }
     },
     "core-js": {
       "version": "3.8.1",
@@ -7453,9 +7489,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mta-local": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/mta-local/-/mta-local-0.1.9.tgz",
-      "integrity": "sha512-AXQQRI2bPFz/1QclcaqMpGJa9vmea2GCe6YfPhmxXJE4k7C79whpaBtL9HW+0eqtN8FDK/oDxboQQffTY3X+7g=="
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/mta-local/-/mta-local-0.1.10.tgz",
+      "integrity": "sha512-uk6KM4w36yHFHEKy7Qkyh8PhuHSAE0C3o84NvKwHzOz1Ux1cKMHdLCHi/Teh7ZwUZj+x+CeInZzKeA7ZjZsuxw=="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "*"
   ],
   "extensionDependencies": [
-    "sapos.yeoman-ui"
+    "sapos.yeoman-ui",
+    "vscode.yaml"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -31,6 +32,14 @@
         "name": "MTA",
         "source": "MTA Validate",
         "label": "Validate MTA development descriptor and extension files"
+      }
+    ],
+    "languages": [
+      {
+        "id": "yaml",
+        "extensions": [
+          ".mtaext"
+        ]
       }
     ],
     "jsonValidation": [
@@ -139,7 +148,7 @@
     "fs-extra": "9.0.1",
     "@vscode-logging/logger": "1.2.2",
     "@sap/swa-for-sapbas-vsx": "1.1.11",
-    "@sap/mta-lib": "1.6.5"
+    "@sap/mta-lib": "1.6.6"
   },
   "devDependencies": {
     "@commitlint/cli": "11.0.0",
@@ -158,6 +167,7 @@
     "chai": "4.2.0",
     "conventional-changelog-cli": "2.1.1",
     "conventional-recommended-bump": "6.1.0",
+    "copy-webpack-plugin": "7.0.0",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "7.17.0",
     "eslint-config-prettier": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -136,8 +136,8 @@
     "format:validate": "prettier --check --ignore-path .gitignore \"**/*.@(ts|js|json|md|yml)\"",
     "lint": "eslint . --ext .ts --fix --max-warnings=0",
     "build": "vsce package",
-    "test": "nyc mocha -p tsconfig.json",
-    "coverage:check": "nyc mocha -p tsconfig.json",
+    "test": "nyc mocha",
+    "coverage:check": "nyc mocha",
     "vscode:prepublish": "webpack --mode production",
     "webpack": "webpack --mode development",
     "webpack:watch": "webpack --mode development --watch"

--- a/tests/commands/mtaBuildCommand.spec.ts
+++ b/tests/commands/mtaBuildCommand.spec.ts
@@ -217,10 +217,4 @@ describe("MTA build command unit tests", () => {
     windowMock.expects("showErrorMessage").withExactArgs(messages.INSTALL_MBT);
     await mtaBuildCommand.mtaBuildCommand(selected as Uri, swa);
   });
-
-  it("mtaBuildCommand - tracking throws error", async () => {
-    sandbox.stub(SWATracker.prototype, "track").throws(new Error("error"));
-    tasksMock.expects("executeTask").never();
-    await mtaBuildCommand.mtaBuildCommand(selected as Uri, swa);
-  });
 });

--- a/tests/utils/utils.spec.ts
+++ b/tests/utils/utils.spec.ts
@@ -6,6 +6,7 @@ import * as sinon from "sinon";
 import { Utils } from "../../src/utils/utils";
 import { SelectionItem } from "../../src/utils/selectionItem";
 import { IChildLogger } from "@vscode-logging/logger";
+import * as fsExtra from "fs-extra";
 
 describe("Utils unit tests", () => {
   const path1 = "some/path/to/file1";
@@ -92,6 +93,23 @@ describe("Utils unit tests", () => {
 
     const response = await Utils.getConfigFileField("field1", loggerImpl);
     expect(response).to.equal(undefined);
+  });
+
+  it("getConfigFileField - fetch field from existing config file", async () => {
+    utilsMock
+      .expects("getConfigFilePath")
+      .once()
+      .returns("path/to/existing/file");
+    // Converting SinonStub because it takes the wrong overload
+    ((sinon.stub(fsExtra, "readFile") as unknown) as sinon.SinonStub<
+      [string, string],
+      Promise<string>
+    >)
+      .withArgs("path/to/existing/file", "utf8")
+      .resolves(`{"field1":"field1_value"}`);
+
+    const response = await Utils.getConfigFileField("field1", loggerImpl);
+    expect(response).to.equal("field1_value");
   });
 
   it("getFilePaths - get paths of a non windows platform", () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,10 +38,12 @@ const config = {
       },
     ],
   },
+  // Enable cloud-mta usage via auto-download, see https://github.com/SAP/cloud-mta#packaging-with-webpack
   node: {
     __dirname: false,
   },
   plugins: [
+    // Enable cloud-mta usage via auto-download, see https://github.com/SAP/cloud-mta#packaging-with-webpack
     new CopyWebpackPlugin({
       patterns: [
         {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const path = require("path");
+const fs = require("fs");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
 const distPath = path.resolve(__dirname, "dist");
 
 /**@type {import('webpack').Configuration}*/
@@ -36,5 +38,23 @@ const config = {
       },
     ],
   },
+  node: {
+    __dirname: false,
+  },
+  plugins: [
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: path.join(require.resolve("mta-local"), "..", "bin"),
+          to: path.resolve(distPath, "bin"),
+        },
+      ],
+    }),
+    function (compiler) {
+      compiler.hooks.done.tap("ExecuteChmodOnBinMta", () => {
+        fs.chmodSync(path.resolve(distPath, "bin", "mta"), "755");
+      });
+    },
+  ],
 };
 module.exports = config;


### PR DESCRIPTION
- Issues in mta.yaml are now marked as errors
- Path validation is removed (since the path can be created during the build)
- Yaml syntax highlighting for mtaext files

Fix:
- mta executable is downloaded if not available for the purpose of validations (it's still required for generators)

### Checklist

- [X] Code compiles correctly
- [ ] Relevant tests were added (unit / contract / integration)
- [ ] Relevant logs were added
- [X] Linting run locally successfully
- [X] All tests pass
- [ ] UA review
- [ ] Design is documented
- [X] Extended the README / documentation, if necessary
- [ ] Open source is approved
