### PR TITLE
fix: mbt not found even if mbt is installed by npm

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -138,8 +138,9 @@ export class Utils {
     const homeDir = os.homedir();
     const response = await Utils.execCommand(cliName, ["-v"], {
       cwd: homeDir,
+      shell: true,
     });
-    if (response.exitCode === "ENOENT") {
+    if (response.exitCode != 0) {
       logger.error(`The ${cliName} Tool is not installed in the environment`);
       void window.showErrorMessage(errMessage);
       return false;


### PR DESCRIPTION
## The Cloud MTA Build Tool is not installed in your environment

On windows, even if you have installed mbt by running the following command

```
npm install -g mbt
```

this error still happens when you right click a mta.yaml file and click 'Build MTA project' in the popup menu.

```
'The Cloud MTA Build Tool is not installed in your environment. Go to https://github.com/SAP/cloud-mta-build-tool to install the tool and try again'
```

This commit is to fix this issue by running the mbt in the shell mode.
![Uploading mbt-not-found.png…]()

